### PR TITLE
Fix comparison logic in Int.Cmp to correctly handle 0 and -0

### DIFF
--- a/int256.go
+++ b/int256.go
@@ -235,6 +235,8 @@ func (z *Int) Cmp(x *Int) (r int) {
 		if z.neg {
 			r = -r
 		}
+	case z.abs.IsZero() && x.abs.IsZero():
+		r = 0
 	case z.neg:
 		r = -1
 	default:

--- a/int256_test.go
+++ b/int256_test.go
@@ -1396,6 +1396,19 @@ func TestInt_Cmp(t *testing.T) {
 			},
 			wantR: 1,
 		},
+		{
+			name: "Should return correct value",
+			fields: fields{
+				abs: uint256.NewInt(0),
+				neg: true,
+			},
+			args: args{
+				x: &Int{
+					abs: uint256.NewInt(0),
+				},
+			},
+			wantR: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This pull request addresses an issue in the `Int.Cmp` function where it was not correctly comparing 0 and -0.

The changes in this PR modify the `Int.Cmp` function to correctly handle this case. Now, 0 and -0 are correctly identified as equal.

In addition to the fix, a new test case has been added to verify the correct behavior of the `Int.Cmp` function when comparing 0 and -0.